### PR TITLE
Bugfix: Set local package dir on windows

### DIFF
--- a/build-windows.sh
+++ b/build-windows.sh
@@ -4,7 +4,9 @@ else
     echo "cmake not available, installing."
     ROOT="$(cygpath -m /)"
     echo "cygwin root: $ROOT"
-    /setup-x86_64.exe --root $ROOT -q --packages=cmake
+    LOCAL_PACKAGE_DIR="$(cygpath -w /var/cache/setup)"
+
+    /setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $(LOCAL_PACKAGE_DIR)
 
     CMAKE_FOLDER="$(find /usr/share -maxdepth 1 -name cmake-*)"
     CMAKE_DIRNAME="$(basename $CMAKE_FOLDER)"

--- a/build-windows.sh
+++ b/build-windows.sh
@@ -6,7 +6,7 @@ else
     echo "cygwin root: $ROOT"
     LOCAL_PACKAGE_DIR="$(cygpath -w /var/cache/setup)"
 
-    /setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $(LOCAL_PACKAGE_DIR)
+    /setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $LOCAL_PACKAGE_DIR
 
     CMAKE_FOLDER="$(find /usr/share -maxdepth 1 -name cmake-*)"
     CMAKE_DIRNAME="$(basename $CMAKE_FOLDER)"


### PR DESCRIPTION
__Issue:__ On `esy@0.4.0`, this package doesn't do a quiet install - since cygwin setup was never run, the local package dir is not cached.

__Fix:__ Explicitly set the local package directory, so that we can stick with a quiet install.