### PR TITLE
Bugfix: esy-cmake hangs on build with esy@0.4.x

### DIFF
--- a/build-windows.sh
+++ b/build-windows.sh
@@ -6,7 +6,7 @@ else
     echo "cygwin root: $ROOT"
     LOCAL_PACKAGE_DIR="$(cygpath -w /var/cache/setup)"
 
-    /setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $LOCAL_PACKAGE_DIR
+    $ROOT/setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $LOCAL_PACKAGE_DIR --site=http://cygwin.mirror.constant.com/ --verbose
 
     CMAKE_FOLDER="$(find /usr/share -maxdepth 1 -name cmake-*)"
     CMAKE_DIRNAME="$(basename $CMAKE_FOLDER)"


### PR DESCRIPTION
__Issue:__ When installing `esy-cmake` with `esy@0.4.x`, `esy` just hangs.

__Defect:__ We pop up the cygwin setup if cmake isn't available. With `esy@0.4.x`, it now uses a newer version of `esy-bash` that doesn't run the installer. Since the values aren't pre-populated, it prompts asking for the cache path.

__Fix:__ Set the mirror site explicitly so that the cygwin installer UI doesn't get blocked.