### PR TITLE
Bugfix: Disable creation of cygwin shortcut

### DIFF
--- a/build-windows.sh
+++ b/build-windows.sh
@@ -6,7 +6,7 @@ else
     echo "cygwin root: $ROOT"
     LOCAL_PACKAGE_DIR="$(cygpath -w /var/cache/setup)"
 
-    $ROOT/setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $LOCAL_PACKAGE_DIR --site=http://cygwin.mirror.constant.com/ --verbose
+    $ROOT/setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $LOCAL_PACKAGE_DIR --site=http://cygwin.mirror.constant.com/ --no-desktop --no-startmenu --no-shortcuts --verbose
 
     CMAKE_FOLDER="$(find /usr/share -maxdepth 1 -name cmake-*)"
     CMAKE_DIRNAME="$(basename $CMAKE_FOLDER)"


### PR DESCRIPTION
__Issue:__ Installing the `esy-cmake` package invokes the installer, which by default places cygwin shortcuts on desktop/start menu/etc.

__Fix:__ Pass in the `--no-desktop`, `--no-shortcuts`, and `--no-startmenu` options. More info here: https://cygwin.com/faq.html#faq.setup.cli