### PR TITLE
Uniform builds on Linux and Macos + Parallel builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,6 @@ cmake:
 	mkdir -p $(BUILDDIR)
 	git clone https://github.com/kitware/cmake $(BUILDDIR)/cmake
 	cd $(BUILDDIR)/cmake; git checkout c4ab098
-	cd $(BUILDDIR)/cmake; ./bootstrap --prefix=$(PREFIX)
-	cd $(BUILDDIR)/cmake; make
+	cd $(BUILDDIR)/cmake; ./bootstrap --prefix=$(PREFIX) --parallel=4
+	cd $(BUILDDIR)/cmake; make -j4
 	cd $(BUILDDIR)/cmake; make install

--- a/build.sh
+++ b/build.sh
@@ -8,7 +8,7 @@ echo Using prefix: $PREFIX
 mkdir -p $BUILDDIR
 git clone https://github.com/kitware/cmake $BUILDDIR/cmake
 cd $BUILDDIR/cmake; git checkout 7700df9b1ef66761cad08cfc08344d5b27660e9f
-cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX
-cd $BUILDDIR/cmake; make
+cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX --parallel=4
+cd $BUILDDIR/cmake; make -j4
 cd $BUILDDIR/cmake; make install
 

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ else
 
     mkdir -p $BUILDDIR
     git clone https://github.com/kitware/cmake $BUILDDIR/cmake
-    cd $BUILDDIR/cmake; git checkout c4ab098
+    cd $BUILDDIR/cmake; git checkout 7700df9b1ef66761cad08cfc08344d5b27660e9f
     cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX
     cd $BUILDDIR/cmake; make
     cd $BUILDDIR/cmake; make install

--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,14 @@
 BUILDDIR=$cur__root/_build
 PREFIX=$cur__install
 
-if which cmake; then
-    echo "Cmake already available, not building"
-else
-    echo Using builddir: $BUILDDIR
-    echo Using prefix: $PREFIX
 
-    mkdir -p $BUILDDIR
-    git clone https://github.com/kitware/cmake $BUILDDIR/cmake
-    cd $BUILDDIR/cmake; git checkout 7700df9b1ef66761cad08cfc08344d5b27660e9f
-    cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX
-    cd $BUILDDIR/cmake; make
-    cd $BUILDDIR/cmake; make install
-fi
+echo Using builddir: $BUILDDIR
+echo Using prefix: $PREFIX
+
+mkdir -p $BUILDDIR
+git clone https://github.com/kitware/cmake $BUILDDIR/cmake
+cd $BUILDDIR/cmake; git checkout 7700df9b1ef66761cad08cfc08344d5b27660e9f
+cd $BUILDDIR/cmake; ./bootstrap --prefix=$PREFIX
+cd $BUILDDIR/cmake; make
+cd $BUILDDIR/cmake; make install
+


### PR DESCRIPTION
This PR builds cmake despite cmake being available in the path and makes sure the same version of cmake is available on Linux and Mac.

@EduardoRFS also added support for parallel builds