### PR TITLE
Fix: Add libuv1 as dependencies

### DIFF
--- a/build-windows.sh
+++ b/build-windows.sh
@@ -6,7 +6,7 @@ else
     echo "cygwin root: $ROOT"
     LOCAL_PACKAGE_DIR="$(cygpath -w /var/cache/setup)"
 
-    $ROOT/setup-x86_64.exe --root $ROOT -q --packages=cmake --local-package-dir $LOCAL_PACKAGE_DIR --site=http://cygwin.mirror.constant.com/ --no-desktop --no-startmenu --no-shortcuts --verbose
+    $ROOT/setup-x86_64.exe --root $ROOT -q --packages=cmake,libuv1 --local-package-dir $LOCAL_PACKAGE_DIR --site=http://cygwin.mirror.constant.com/ --no-desktop --no-startmenu --no-shortcuts --verbose
 
     CMAKE_FOLDER="$(find /usr/share -maxdepth 1 -name cmake-*)"
     CMAKE_DIRNAME="$(basename $CMAKE_FOLDER)"


### PR DESCRIPTION
cmake from cygwin need cyguv-1.dll provided in package libuv1. This unlock cold esy-harfbuzz build o windows.